### PR TITLE
correct GH repo name

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -25,9 +25,7 @@ jobs:
 
     - name: Setup KO
       uses: ko-build/setup-ko@v0.6
-      env:
-        KO_DOCKER_REPO: ghcr.io/mrwormhole
 
     - name: Publish
       run: |
-        ko build ./cmd/emailer --platform="linux/amd64,linux/arm64" --base-import-paths --tags ${{github.ref_name}}
+        ko build ./cmd/emailer --platform="linux/amd64,linux/arm64" --bare --tags ${{github.ref_name}}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,9 +4,6 @@ on:
   push:
     tags:
       - 'v*.*.*'
-  pull_request:
-    branches:
-      - "main"
 
 permissions:
   contents: read
@@ -28,4 +25,4 @@ jobs:
 
     - name: Publish
       run: |
-        ko build ./cmd/emailer --platform="linux/amd64,linux/arm64" --bare
+        ko build ./cmd/emailer --platform="linux/amd64,linux/arm64" --bare --tags ${{github.ref_name}}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,6 +4,9 @@ on:
   push:
     tags:
       - 'v*.*.*'
+  pull_request:
+    branches:
+      - "main"
 
 permissions:
   contents: read
@@ -22,6 +25,8 @@ jobs:
 
     - name: Setup KO
       uses: ko-build/setup-ko@v0.6
+      env:
+        KO_DOCKER_REPO: ghcr.io/mrwormhole
 
     - name: Publish
       run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -28,4 +28,4 @@ jobs:
 
     - name: Publish
       run: |
-        ko build ./cmd/emailer --platform="linux/amd64,linux/arm64" --bare --tags ${{github.ref_name}}
+        ko build ./cmd/emailer --platform="linux/amd64,linux/arm64" --bare


### PR DESCRIPTION
corrects the GH container repo name from "email/email" (monorepo naming of ko) to "email"